### PR TITLE
os.write wants bytes, not str.

### DIFF
--- a/sourcecodebrowser/plugin.py
+++ b/sourcecodebrowser/plugin.py
@@ -413,7 +413,8 @@ class SourceCodeBrowserPlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.C
                         contents = document.get_text(document.get_start_iter(),
                                                      document.get_end_iter(),
                                                      True)
-                        os.write(fd, contents)
+                        encoding = document.get_encoding()
+                        os.write(fd, contents.encode(encoding.get_charset().lower()))
                         os.close(fd)
                         while Gtk.events_pending():
                             Gtk.main_iteration()


### PR DESCRIPTION
Plugin retrieves the content of the document as a string, and tries to write it in a file.  But os.write refuses to do magical conversion to bytes. It is necessary to get document encoding (got here as a GeditEncoding) and pass it as a python code (as in http://docs.python.org/3.3/library/codecs.html#standard-encodings). 

The PR is imperfect (works at least for utf8) as I don't know how to automatically convert GeditEncoding to python codecs.
