### PR TITLE
Add __all__ to files

### DIFF
--- a/sourcecodebrowser/__init__.py
+++ b/sourcecodebrowser/__init__.py
@@ -1,3 +1,4 @@
 import plugin
 from plugin import SourceCodeBrowserPlugin
 
+__all__ = ['plugin','SourceCodeBrowserPlugin']


### PR DESCRIPTION
Added __all__ lists to:
* __init__.py
* plugin.py

Why is this important? It makes python not include built-ins and librares.